### PR TITLE
Include year in link to party

### DIFF
--- a/include_pouet/pouet-party.php
+++ b/include_pouet/pouet-party.php
@@ -48,7 +48,7 @@ class PouetParty extends BM_Class
         }
         if ($year) {
             return sprintf(
-                "<a href='party.php?which=%d&amp;when=%d'>%s</a> %d",
+                "<a href='party.php?which=%d&amp;when=%d'>%s %d</a>",
                 $this->id,
                 $year,
                 _html($this->name),


### PR DESCRIPTION
When the year is available, the link points to a specific party, so the link label should reflect that.

PR recreated as suggested in https://github.com/pouetnet/pouet-v2.0/pull/110#issuecomment-2746293682.